### PR TITLE
Fix cleaning mode select showing unknown when device is returning (v0.8.13)

### DIFF
--- a/custom_components/aiper/manifest.json
+++ b/custom_components/aiper/manifest.json
@@ -15,5 +15,5 @@
     "certifi>=2024.0.0",
     "requests>=2.31.0"
   ],
-  "version": "0.8.12"
+  "version": "0.8.13"
 }

--- a/custom_components/aiper/select.py
+++ b/custom_components/aiper/select.py
@@ -100,6 +100,13 @@ def _normalize_mode_id(value: Any) -> int | None:
             if possible.lstrip("-").isdigit():
                 return int(possible)
 
+        # Partial match: "Smart cleaning" → MODE_MAP label "Smart" is in "smart cleaning".
+        normalized = " ".join(text.replace("_", " ").replace("-", " ").split()).casefold()
+        for mid, label in MODE_MAP.items():
+            label_norm = label.casefold()
+            if label_norm and label_norm in normalized:
+                return int(mid)
+
         return None
 
     if isinstance(value, dict):
@@ -362,6 +369,14 @@ class AiperCleaningModeSelect(AiperSelectBase):
                         return mode_id
         except Exception:
             pass
+
+        # Last cleaning history is a better UX fallback than showing the select as unknown
+        # when the robot has just finished / is returning and the live state has no mode.
+        dev = (self.coordinator.data or {}).get(self._sn) or {}
+        if isinstance(dev, dict):
+            mode_id = _normalize_mode_id(dev.get("_ha_last_cleaning_mode"))
+            if mode_id is not None:
+                return mode_id
 
         return None
 


### PR DESCRIPTION
## Summary

- Adds `_ha_last_cleaning_mode` fallback in `_get_current_mode_id`: when the robot is Returning or Idle and the live MQTT/REST state has no mode field, the select now shows the last mode from cleaning history instead of flipping to `unknown`
- Adds partial-label matching in `_normalize_mode_id` so API string variants like `"Smart cleaning"` resolve to the correct mode ID (e.g. 1)
- Bumps version to 0.8.13

## Root cause

The device (firmware V2.0.0, Scuba X1) reports no `mode` in its shadow/REST state while Returning. The previous code had no fallback and returned `None`, which HA rendered as `unknown` in the select control. Cleaning history already recorded the mode (shown correctly in the "Last Cleaning Mode" sensor), but that value was never consulted by the select.

## Test plan

- [ ] Install v0.8.13 in Home Assistant
- [ ] Confirm Cleaning mode select shows `Smart` (or whichever mode was last used) instead of `unknown` while device is Returning/Idle
- [ ] Confirm Clean path select still works
- [ ] Confirm Activity log no longer shows "Cleaning mode became unknown"
- [ ] HACS validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)