### PR TITLE
Fix clean path select: instant UI update + endpoint caching (v0.8.14)

### DIFF
--- a/custom_components/aiper/api.py
+++ b/custom_components/aiper/api.py
@@ -93,6 +93,10 @@ class AiperApi:
         self._rest_lock = threading.Lock()
         self._rest_min_interval = 0.8  # seconds between REST calls
         self._rest_next_allowed = 0.0
+
+        # Cache the last-working clean-path endpoint+body so repeated calls skip
+        # the full 12-path scan.  Keyed by SN.
+        self._clean_path_ok: dict[str, dict] = {}
         self._session.headers.update({
             "Content-Type": "application/json",
             "version": "3.0.0",  # App version
@@ -794,34 +798,47 @@ def _request_with_backoff(self, method: str, url: str, *, headers: dict, json_bo
                     bodies.append(b)
         bodies.extend(base_bodies)
 
-        rest_ok = False
-        for path in candidate_paths:
-            for body in bodies:
-                payload = None
+        def _try_path_body(path: str, body: dict) -> bool:
+            payload = None
+            try:
+                payload = self._call_with_zoneid(sn, lambda p=path, b=body: self._call_encrypted("POST", p, b))
+            except Exception as err:
+                _LOGGER.debug("Clean path update encrypted call failed (%s): %s", path, err)
+            if not payload or not self._is_success(payload):
                 try:
-                    payload = self._call_with_zoneid(sn, lambda p=path, b=body: self._call_encrypted("POST", p, b))
+                    payload = self._call_with_zoneid(sn, lambda p=path, b=body: self._call_plain("POST", p, b))
                 except Exception as err:
-                    _LOGGER.debug("Clean path update encrypted call failed (%s): %s", path, err)
+                    _LOGGER.debug("Clean path update plain call failed (%s): %s", path, err)
+            if payload and self._is_success(payload):
+                _LOGGER.debug(
+                    "Clean path REST OK via %s (code=%s successful=%s message=%s) keys=%s",
+                    path, payload.get("code"), payload.get("successful"),
+                    payload.get("message"), list(body.keys()),
+                )
+                return True
+            return False
 
-                if not payload or not self._is_success(payload):
-                    try:
-                        payload = self._call_with_zoneid(sn, lambda p=path, b=body: self._call_plain("POST", p, b))
-                    except Exception as err:
-                        _LOGGER.debug("Clean path update plain call failed (%s): %s", path, err)
+        rest_ok = False
 
-                if payload and self._is_success(payload):
-                    rest_ok = True
-                    _LOGGER.debug(
-                        "Clean path REST OK via %s (code=%s successful=%s message=%s) keys=%s",
-                        path,
-                        payload.get("code"),
-                        payload.get("successful"),
-                        payload.get("message"),
-                        list(body.keys()),
-                    )
+        # Try the last-working combination first to avoid the full scan on every call.
+        cached = self._clean_path_ok.get(sn)
+        if cached:
+            cached_body = dict(cached["body"])
+            for k in list(cached_body.keys()):
+                if k in ("cleanPath", "cleanPathSetting", "clean_path_setting"):
+                    cached_body[k] = int(value)
+            if _try_path_body(cached["path"], cached_body):
+                rest_ok = True
+
+        if not rest_ok:
+            for path in candidate_paths:
+                for body in bodies:
+                    if _try_path_body(path, body):
+                        rest_ok = True
+                        self._clean_path_ok[sn] = {"path": path, "body": body}
+                        break
+                if rest_ok:
                     break
-            if rest_ok:
-                break
 
         mqtt_published = False
         if self.is_mqtt_connected():

--- a/custom_components/aiper/manifest.json
+++ b/custom_components/aiper/manifest.json
@@ -15,5 +15,5 @@
     "certifi>=2024.0.0",
     "requests>=2.31.0"
   ],
-  "version": "0.8.13"
+  "version": "0.8.14"
 }

--- a/custom_components/aiper/select.py
+++ b/custom_components/aiper/select.py
@@ -523,6 +523,15 @@ class AiperCleanPathSelect(AiperSelectBase):
 
         self.coordinator.note_command_sent(self._sn, "clean_path", path_id)
 
+        # Set cache optimistically before the API call so the UI updates immediately
+        # rather than waiting for the full REST round-trip (which can take 30+ s when
+        # the first few endpoint variants time out).
+        try:
+            self.coordinator.set_clean_path_cache(self._sn, path_id)
+            self.async_write_ha_state()
+        except Exception:
+            pass
+
         ok = False
         try:
             ok = await self.hass.async_add_executor_job(
@@ -531,24 +540,29 @@ class AiperCleanPathSelect(AiperSelectBase):
                 path_id,
             )
         except Exception as err:
+            # Revert optimistic cache on failure.
+            if cur is not None:
+                try:
+                    self.coordinator.set_clean_path_cache(self._sn, cur)
+                    self.async_write_ha_state()
+                except Exception:
+                    pass
             self.coordinator.note_command_failed(self._sn, "clean_path", path_id, reason=str(err))
             raise HomeAssistantError(f"Failed to set clean path: {err}") from err
         if not ok:
+            # Revert optimistic cache on rejection.
+            if cur is not None:
+                try:
+                    self.coordinator.set_clean_path_cache(self._sn, cur)
+                    self.async_write_ha_state()
+                except Exception:
+                    pass
             self.coordinator.note_command_failed(self._sn, "clean_path", path_id, reason="device rejected")
             if not self.coordinator.api.is_mqtt_connected():
                 raise HomeAssistantError(
                     "Failed to set clean path: cloud control is unavailable because MQTT is not connected. Enable MQTT in the Aiper integration options."
                 )
             raise HomeAssistantError("Failed to set clean path: device rejected the command")
-
-
-
-        # Optimistically cache the selection. Some firmwares never report cleanPath
-        # in reported shadow state, so without this the entity can remain Unknown.
-        try:
-            self.coordinator.set_clean_path_cache(self._sn, path_id)
-        except Exception:
-            pass
 
         # Ask for a shadow refresh and a coordinator refresh.
         try:


### PR DESCRIPTION
## Summary

- **Instant UI update**: clean path cache is now set *before* the API call, so the select flips immediately in the HA UI instead of freezing for 30+ seconds while the REST call completes. Cache is reverted if the call fails.
- **Endpoint caching**: the last-working REST endpoint+body is remembered per device, so the next clean path change goes straight to the known-good endpoint instead of scanning all 12 variants.

## Test plan

- [ ] Change Clean path → should flip in HA UI within ~1 second
- [ ] Verify device actually changes path (activity log entry appears)
- [ ] Change again immediately — should still be fast (uses cached endpoint)
- [ ] HACS/hassfest validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)