### PR TITLE
Release 1.0.4: fix S2 sensors and remove stale consumable entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.0.4] - 2026-06-02
+
+### Fixed
+
+- **Surfer S2** — Last Cleaning Duration and Total Cleaning Time sensors now populate correctly for S2 devices whose history API uses `cleanTimeMin` (integer minutes) or related `cleanTimeMinute` / `cleaningTimeMin` / `cleanTimeSec` / `cleanTimeHour` keys. Unit detection is now key-name-aware so no ambiguous heuristic applies to those fields.
+- **Surfer S2** — Solar Charging binary sensor now updates from MQTT payloads that send `solarStatus` (camelCase) instead of `solar_status`.
+- **All devices** — Stale "Unavailable" consumable entities left over from v0.7.0 (Roller Brush Remaining, Roller Brush Remaining %, MicroMesh Filter Remaining, etc.) are automatically removed from the entity registry on startup. Those entities were replaced by consolidated percent sensors (Roller Brush, MicroMesh Filter, Caterpillar Tread) in a prior refactor; the old registrations persisted and caused the duplicate-entity appearance in the Diagnostics view.
+- Added debug-level logging of the raw and parsed cleaning history response to assist future diagnostics.
+
 ## [1.0.1] - 2026-05-26
 
 ### Fixed

--- a/custom_components/aiper/__init__.py
+++ b/custom_components/aiper/__init__.py
@@ -126,6 +126,23 @@ async def _cleanup_legacy_entities(
             ent_reg.async_remove(ent.entity_id)
 
     # Remove legacy sensors by unique_id / entity_id patterns.
+    # v0.7.0 used separate _remaining/_percent/_last_replacement entities per
+    # consumable; later releases merged these into a single percent sensor per
+    # consumable type (roller_brush, micromesh_filter, caterpillar_tread, propeller).
+    _LEGACY_CONSUMABLE_SUFFIXES = (
+        "_roller_brush_remaining",
+        "_roller_brush_percent",
+        "_roller_brush_last_replacement",
+        "_micromesh_remaining",
+        "_micromesh_percent",
+        "_micromesh_last_replacement",
+        "_tread_remaining",
+        "_tread_percent",
+        "_tread_last_replacement",
+        "_propeller_remaining",
+        "_propeller_percent",
+        "_propeller_last_replacement",
+    )
     legacy_unique_ids: set[str] = set()
     for sn in serial_numbers:
         legacy_unique_ids.update(
@@ -136,6 +153,7 @@ async def _cleanup_legacy_entities(
                 f"{sn}_power",
             }
         )
+        legacy_unique_ids.update(f"{sn}{suffix}" for suffix in _LEGACY_CONSUMABLE_SUFFIXES)
 
     for ent in list(entries):
         if ent.domain != "sensor":

--- a/custom_components/aiper/coordinator.py
+++ b/custom_components/aiper/coordinator.py
@@ -400,6 +400,26 @@ def _parse_cleaning_history(raw: Any) -> tuple[int | None, float | None, list[di
                 return value
         return None
 
+    # Duration key lookup table: (key, unit_hint). Keys with explicit unit hints in
+    # their name (e.g. "cleanTimeMin") bypass the heuristic unit detection.
+    _DURATION_KEY_UNITS: tuple[tuple[str, str | None], ...] = (
+        ("cleanTimeMin", "min"),
+        ("cleanTimeMinute", "min"),
+        ("cleaningTimeMin", "min"),
+        ("cleanTimeSec", "sec"),
+        ("cleanTimeSecond", "sec"),
+        ("cleanTimeHour", "hour"),
+        ("cleanTimeHours", "hour"),
+        ("duration", None),
+        ("durationTime", None),
+        ("cleanTime", None),
+        ("cleaningTime", None),
+        ("runTime", None),
+        ("useTime", None),
+        ("lastTime", None),
+        ("timeUsed", None),
+    )
+
     records: list[dict[str, Any]] = []
     for item in rec_list:
         if not isinstance(item, dict):
@@ -413,11 +433,25 @@ def _parse_cleaning_history(raw: Any) -> tuple[int | None, float | None, list[di
         if mode_name is None and mode_id is not None:
             mode_name = str(mode_id)
 
-        duration_value = _deep_get(
-            item,
-            ("duration", "durationTime", "cleaningTime", "runTime", "useTime", "lastTime", "timeUsed"),
-        )
-        duration_min = _minutes_from_value(duration_value)
+        duration_min: float | None = None
+        for _dur_key, _unit_hint in _DURATION_KEY_UNITS:
+            _dur_val = item.get(_dur_key)
+            if _dur_val is None:
+                _dur_val = _deep_get(item, (_dur_key,))
+            if _dur_val is None:
+                continue
+            _num = _number(_dur_val)
+            if _num is None or _num < 0:
+                continue
+            if _unit_hint == "min":
+                duration_min = _num
+            elif _unit_hint == "sec":
+                duration_min = _num / 60.0
+            elif _unit_hint == "hour":
+                duration_min = _num * 60.0
+            else:
+                duration_min = _minutes_from_value(_dur_val)
+            break
         records.append(
             {
                 "mode_id": mode_id_int,
@@ -729,11 +763,19 @@ class AiperDataUpdateCoordinator(DataUpdateCoordinator[DevicesState]):
                     except Exception as err:
                         _LOGGER.debug("Cleaning history fetch failed for %s: %s", sn, err)
                     if raw_hist is not None:
+                        _LOGGER.debug("Cleaning history raw for %s: %s", sn, raw_hist)
                         try:
                             total_count, total_hours, records = _parse_cleaning_history(raw_hist)
                         except Exception as err:
                             _LOGGER.debug("Cleaning history parse failed for %s: %s", sn, err)
                             total_count, total_hours, records = None, None, []
+                        _LOGGER.debug(
+                            "Cleaning history parsed for %s: count=%s hours=%s records=%d",
+                            sn,
+                            total_count,
+                            total_hours,
+                            len(records),
+                        )
                         self._history_cache[sn] = {
                             "total_count": total_count,
                             "total_hours": total_hours,
@@ -979,6 +1021,7 @@ class AiperDataUpdateCoordinator(DataUpdateCoordinator[DevicesState]):
                 "warn_code",
                 "temp",
                 "solar_status",
+                "solarStatus",
                 "link",
                 "cleanPath",
                 "clean_path",

--- a/custom_components/aiper/manifest.json
+++ b/custom_components/aiper/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "awsiotsdk>=1.29.0"
   ],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/custom_components/aiper/state.py
+++ b/custom_components/aiper/state.py
@@ -405,8 +405,9 @@ def normalize_machine_update(
         updates["runtime"] = EntityState(_centihours_to_hours(mqtt.get("run_time")))
     if mqtt.get("in_water") is not None:
         updates["in_water"] = EntityState(bool(mqtt.get("in_water")))
-    if mqtt.get("solar_status") is not None:
-        updates["solar_charging"] = EntityState(mqtt.get("solar_status") == 1)
+    solar_status_raw = mqtt.get("solar_status") if "solar_status" in mqtt else mqtt.get("solarStatus")
+    if solar_status_raw is not None:
+        updates["solar_charging"] = EntityState(solar_status_raw == 1)
     if mqtt.get("link") is not None:
         updates["linked"] = EntityState(online and mqtt.get("link") == 1)
     if mqtt.get("cleanPath") is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-aiper"
-version = "1.0.3"
+version = "1.0.4"
 description = "Development tooling for the Aiper Home Assistant custom integration."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
+import pytest
+
 from custom_components.aiper.coordinator import _clean_path_value, _parse_cleaning_history, _parse_consumables
 from custom_components.aiper.state import (
     _centihours_to_hours,
@@ -67,6 +69,12 @@ def test_machine_solar_status_uses_observed_integer_payload() -> None:
     """Solar charging comes from MQTT Machine.solar_status as an integer flag."""
     assert normalize_machine_update({"model": "Surfer_S2"}, {"solar_status": 1})["solar_charging"].value is True
     assert normalize_machine_update({"model": "Surfer_S2"}, {"solar_status": 0})["solar_charging"].value is False
+
+
+def test_machine_solar_status_camel_case_alias() -> None:
+    """solarStatus (camelCase) is treated as an alias for solar_status."""
+    assert normalize_machine_update({"model": "Surfer_S2"}, {"solarStatus": 1})["solar_charging"].value is True
+    assert normalize_machine_update({"model": "Surfer_S2"}, {"solarStatus": 0})["solar_charging"].value is False
 
 
 def test_machine_status_update_coerces_status_without_losing_operating_status() -> None:
@@ -196,6 +204,41 @@ def test_w2_alarm_update_decodes_alarm_bitmask() -> None:
 
     assert state["warning"].value == "pH constant value, Battery low"
     assert state["warning"].attributes == {"code": 8448, "codes": [256, 8192], "time": "now"}
+
+
+def test_parse_cleaning_history_surfer_s2_clean_time_min_keys() -> None:
+    """Surfer S2 history records may use cleanTimeMin (minutes) as the duration key."""
+    total_count, total_hours, records = _parse_cleaning_history(
+        {
+            "code": "200",
+            "data": {
+                "totalCleanCount": 3,
+                "list": [
+                    {
+                        "mode": 1,
+                        "cleanDate": "2026-05-24",
+                        "cleanTimeMin": 45,
+                    },
+                    {
+                        "mode": 1,
+                        "cleanDate": "2026-05-25",
+                        "cleanTimeMin": 90,
+                    },
+                    {
+                        "mode": 1,
+                        "cleanDate": "2026-05-26",
+                        "cleanTimeMin": 60,
+                    },
+                ],
+            },
+        }
+    )
+
+    assert total_count == 3
+    assert records[0]["duration_min"] == 60.0
+    assert records[1]["duration_min"] == 90.0
+    # total_hours derived from record sum: (45+90+60)/60 = 3.25 h
+    assert total_hours == pytest.approx(3.25, rel=0.01)
 
 
 def test_parse_cleaning_history_restores_totals_and_last_record() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "ha-aiper"
-version = "1.0.3"
+version = "1.0.4"
 source = { virtual = "." }
 dependencies = [
     { name = "awsiotsdk" },


### PR DESCRIPTION
## Summary

- **Surfer S2** — `Last Cleaning Duration` and `Total Cleaning Time` now populate: added `cleanTimeMin`/`cleanTimeMinute`/`cleaningTimeMin` duration key variants with key-name-aware unit detection.
- **Surfer S2** — `Solar Charging` now updates from `solarStatus` (camelCase) MQTT payloads.
- **All devices** — Stale v0.7.0 consumable entities (`roller_brush_remaining`, `roller_brush_percent`, etc.) automatically removed from entity registry on startup, eliminating the "Unavailable" duplicates in the Diagnostics view.
- Debug logging added for raw/parsed cleaning history to aid future diagnostics.

## Test plan

- [ ] CI passes green (unit tests, ruff, mypy, hassfest)
- [ ] Merge to main only after CI green
- [ ] Tag v1.0.4 to trigger release

Closes #6 (partially — addresses rp-1981's comment about S2 unavailable sensors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)