### PR TITLE
Bump version to 1.0.5: HA 2026.6 OptionsFlow compatibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.5] - 2026-06-05
+
+### Fixed
+
+- **HA 2026.6 compatibility** — `OptionsFlowHandler` no longer overrides `__init__` to store `config_entry`; it now uses the native `self.config_entry` property injected by the framework, eliminating a deprecated pattern that would break in a future HA release.
+
 ## [1.0.4] - 2026-06-02
 
 ### Fixed

--- a/custom_components/aiper/config_flow.py
+++ b/custom_components/aiper/config_flow.py
@@ -163,24 +163,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> OptionsFlowHandler:
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options for the integration."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        # Home Assistant exposes a read-only `config_entry` property on OptionsFlow.
-        # Internally, it reads from `_config_entry`, so set that attribute instead
-        # of attempting to assign to the property.
-        self._config_entry = config_entry
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        current = self._config_entry.options
+        current = self.config_entry.options
         schema = vol.Schema(
             {
                 vol.Optional(CONF_MQTT_DEBUG, default=current.get(CONF_MQTT_DEBUG, False)): bool,

--- a/custom_components/aiper/manifest.json
+++ b/custom_components/aiper/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "awsiotsdk>=1.29.0"
   ],
-  "version": "1.0.4"
+  "version": "1.0.5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-aiper"
-version = "1.0.4"
+version = "1.0.5"
 description = "Development tooling for the Aiper Home Assistant custom integration."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "ha-aiper"
-version = "1.0.4"
+version = "1.0.5"
 source = { virtual = "." }
 dependencies = [
     { name = "awsiotsdk" },


### PR DESCRIPTION
## Summary

- Remove stale `OptionsFlowHandler.__init__` override that manually set `self._config_entry` as a workaround
- Use the native `self.config_entry` property that HA injects into `OptionsFlow` instances (available since HA 2024.4)
- Passing `config_entry` to the constructor is deprecated and would become a hard error in a future HA release

## Test plan

- [ ] Install on HA 2026.6 and verify the options flow still opens and saves correctly (MQTT debug toggle, metadata refresh hours)
- [ ] Confirm no deprecation warnings in HA logs related to `OptionsFlow`

## Issue #22 — Free Chlorine (HydroComm)

No code change needed: the `rcl` sensor only updates when the device emits a WQS payload containing an `rcl` field. HydroComm units without a chlorine probe won't report it, so the sensor stays static. Users can safely hide/disable the entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)